### PR TITLE
Update ng-packagr version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "karma-coverage-istanbul-reporter": "~2.0.0",
     "karma-jasmine": "~1.1.1",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "ng-packagr": "^3.0.0",
+    "ng-packagr": "^4.7.1",
     "protractor": "~5.3.0",
     "ts-node": "^7.0.0",
     "tsickle": ">=0.29.0",


### PR DESCRIPTION
Updated the ng-packagr version to fix the invalid export module names in the built package for Angular 7